### PR TITLE
Updates to use an Aggregated Query

### DIFF
--- a/integration.js
+++ b/integration.js
@@ -172,9 +172,10 @@ const getJobMessages = async (entity, options) => {
   if (createdJobId) {
     results = await gaxios.request({
       method: 'GET',
-      url: `https://api${options.apiDeployment.value}sumologic.com/api/v1/search/jobs/${createdJobId.jobId}/messages?offset=0&limit=10`
+      url: `https://api${options.apiDeployment.value}sumologic.com/api/v1/search/jobs/${createdJobId.jobId}/records?offset=0&limit=50`
     });
   }
+  results.data.messages = results.data.records;
   return {
     entity,
     data:
@@ -189,15 +190,22 @@ function getSummary(data) {
   let cache = {};
 
   if (Object.keys(data).length > 0) {
-    const totalMessages = data.messages.length;
-    tags.push(`Messages: ${totalMessages}`);
+    const totalRecords = data.messages.length;
+    tags.push(`Sources: ${totalRecords}`);
+  }
+
+  if (Object.keys(data).length > 0) {
+    const totalCount = Object.values(data.messages).reduce((sum, currentObject) => {
+      return sum + parseInt(currentObject.map.count,10);
+    }, 0);
+    tags.push(`Messages: ${totalCount}`);
   }
 
   if (Object.keys(data).length > 0) {
     data.messages.map((message) => {
-      if (!cache[message.map._source]) {
-        tags.push(`_Source: ${message.map._source}`);
-        cache[message.map._source] = true;
+      if (!cache[message.map._sourcecategory]) {
+        tags.push(`src: ${message.map._sourcecategory}`);
+        cache[message.map._sourcecategory] = true;
       }
     });
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sumo-logic",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "main": "./integration.js",
   "private": true,
   "dependencies": {

--- a/templates/block.hbs
+++ b/templates/block.hbs
@@ -6,7 +6,7 @@
         class="nav-link {{if message.showMessages "active"}}"
         href="#"
       >
-        Message #{{inc index}}
+        Record #{{inc index}}
       </a>
     </li>
     <li class="nav-item">
@@ -37,7 +37,13 @@
 
   {{#if message.showMessages}}
     <div class="tab-container fields-block scrollable-block mt-1">
-      <pre>{{message.map._raw}}</pre>
+      {{#each-in message.map as |key value|}}
+        {{#if (eq key "_sourcecategory")}}
+          <span class="p-value">{{value}}</span>
+          {{else}}
+          <span class="p-key">{{key}}:</span><span class="p-value">{{value}}</span>
+        {{/if}}
+      {{/each-in}}
     </div>
   {{/if}}
 


### PR DESCRIPTION
This PR is mostly for sharing purposes. It was not tested with a wide range of queries to ensure it would work. There are a lot of ways this can break (e.g. aggregate fields like `count` or `_sourcecategory` not existing). Some additional options, search parsing, etc could make it more resilient.

The current integration retrieves search job results from the `/messages` endpoint, which just returns a list of messages, even if the search job has an aggregate function (e.g. `| count by _sourcecategory`).

In order to address this, we can use the `records` endpoint, which returns a fairly similar data format (biggest different being it's `results.data.records` instead of `results.data.messages`, which we can sort of skip over by just setting `.messages` equal to `.records`). Beyond that, some tweaks to tags and a bit of formatting to account for the lack of a `_raw` field in the search.

For demonstration purposes, here is the query being used:
```
_sourceCategory=* "{{entity}}" 
| count as count, first(_messageTime) as first, last(_messageTime) as last by _sourceCategory 
| formatDate(last, "yyyy-MM-dd HH:mm:ss'Z'") as firstSeen 
| formatDate(first, "yyyy-MM-dd HH:mm:ss'Z'") as lastSeen 
| fields - first, last 
| sort +_sourceCategory
```

